### PR TITLE
Updated front-end to allow for remotely hosted service

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,18 @@ This service presents users with product descriptions for a specific product.
 
 ## Usage
 
-> Some usage instructions
+### Update Bundle
 Before running the application for the first time, be sure to repack the bundle
 > `npm run webstart`
 
+### Create a Config File
+An example configuration file has been provided for your convenience in the root directory (`exampleConfig.json`).
+
+1. Make a copy of the `exampleConfig.json` file
+2. Rename the copy to `config.json`
+3. Update the details of the `config.json` for your needs.
+
+### Run the service
 Once this is in place, you will be able to start the application with a node server.
 > `npm start`
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import axios from 'axios';
+import normalizePort from 'normalize-port';
 
 import Features from './components/Features.jsx';
 import TechSpecs from './components/TechSpecs.jsx';
-import normalizePort from 'normalize-port';
+import config from '../../config.json'
 
-var port = normalizePort(process.env.PORT || '8081');
+const environment = config.currentEnvironment;
+const host = config[environment].svc_host;
+const port = normalizePort(process.env.PORT || '8081');
 
 
 class Productdescriptions extends React.Component {
@@ -21,7 +24,7 @@ class Productdescriptions extends React.Component {
 
   componentDidMount(){
     let id = window.location.pathname.replace(/\/product\//,'');
-    let instance = axios.create({baseURL:`http://localhost:${port}`})
+    let instance = axios.create({baseURL:`http://${host}:${port}`})
     instance
       .get(`/product/data/` + id)
       .then(productData => {

--- a/database/connectPg.js
+++ b/database/connectPg.js
@@ -1,13 +1,13 @@
 const { Client } = require('pg');
 const config = require('../config.json')
 
-const environment = "production" // options are 'development' or 'production'
+const environment = config.currentEnvironment;
 
-const host = config[environment].host;
-const user = config[environment].username;
-const pw = config[environment].password;
-const db = config[environment].database;
-const port = config[environment].port;
+const host = config[environment].db_host;
+const user = config[environment].db_username;
+const pw = config[environment].db_password;
+const db = config[environment].db_database;
+const port = config[environment].db_port;
 const conString = `postgres://${user}:${pw}@${host}:${port}/${db}`;
 
 const client = new Client({

--- a/exampleConfig.json
+++ b/exampleConfig.json
@@ -1,0 +1,21 @@
+{ 
+  "currentEnvironment": "production",
+  "development" : 
+  {
+    "db_database":"your_database",
+    "db_username":"your_user",
+    "db_password":"your_password",
+    "db_port":"5432",
+    "db_host":"localhost",
+    "svc_host": "localhost"
+  },
+  "production" :
+  {
+    "db_database":"your_database",
+    "db_username":"your_user",
+    "db_password":"your_password",
+    "db_port":"5432",
+    "db_host":"db_remote_host.com",
+    "svc_host": "servicie_remote_host.com"
+  }
+}


### PR DESCRIPTION
Continuing the theme of remote-dbs, though the earlier contributions to this fork allowed for a remote DB, once the service stopped being hosted locally, it failed.

These changes enable a remote DB even when the service is not running locally by:

1. Setting the `baseURL` dynamically based on the `config.json`
2. Abstracting the environment to the `config.json` to eliminate duplication

Other tweaks include updates to the Readme and the addition of a sample configuration file. 